### PR TITLE
Long names no longer break our checkin table

### DIFF
--- a/hamdb/client.go
+++ b/hamdb/client.go
@@ -126,7 +126,7 @@ func (c *Client) Stop() {
 
 func (c *Client) lookup(ctx context.Context, callsign string) (Response, error) {
 	var resp Response
-	callsign = strings.TrimSpace(callsign)
+	callsign = strings.ToUpper(strings.TrimSpace(callsign))
 	url := fmt.Sprintf("%s/%s/json/%s", c.baseURL, callsign, c.appName)
 
 	l := c.log.With("callsign", callsign, "url", url)

--- a/internal/handlers/net.go
+++ b/internal/handlers/net.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi"
 
@@ -157,9 +158,9 @@ func (h Net) Checkin(w http.ResponseWriter, r *http.Request) {
 
 	inputErrs := views.CheckinFormErrors{}
 	input := views.CheckinFormInput{
-		Callsign: r.Form.Get("call-sign"),
-		Name:     r.Form.Get("name"),
-		Traffic:  r.Form.Get("traffic"),
+		Callsign: strings.ToUpper(strings.TrimSpace(r.Form.Get("call-sign"))),
+		Name:     strings.TrimSpace(r.Form.Get("name")),
+		Traffic:  strings.TrimSpace(r.Form.Get("traffic")),
 	}
 	if err := validate.Struct(input); err != nil {
 		errs := err.(validator.ValidationErrors)

--- a/internal/handlers/static/custom.css
+++ b/internal/handlers/static/custom.css
@@ -379,7 +379,7 @@ html {
 .traffic-data thead th {
   font-weight: bold;
   text-align: left;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 0;
   border-top: 1px solid var(--border-color-softer);
   background: var(--background-color-softer);
   position: sticky;
@@ -410,6 +410,17 @@ html {
 
 .traffic-data tbody tr:nth-child(even) {
   background-color: var(--background-color-softer);
+}
+
+.traffic-data tbody td {
+  vertical-align: top;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  text-align: left;
+
+-webkit-hyphens: auto;
+   -moz-hyphens: auto;
+        hyphens: auto;
 }
 
 .traffic-data tbody td:first-child {
@@ -451,6 +462,22 @@ html {
   border-radius: 0.4rem;
   color: var(--text-color-softer);
   font-size: 1.54rem;
+}
+
+.traffic-data .checkin-name {
+  max-width: 7em;
+}
+
+.traffic-data .checkin-callsign {
+  width: 7em;
+}
+
+.traffic-data .checkin-location {
+  width: 20em;
+}
+
+.traffic-data .checkin-time-in {
+  width: 7em;
 }
 
 .timeline {

--- a/internal/services/net.go
+++ b/internal/services/net.go
@@ -58,7 +58,7 @@ func (n net) Checkin(ctx context.Context, stream string, checkin *models.NetChec
 			Event.Create(ctx, stream, events.NetCheckinVerified{
 				ID: id.String(),
 
-				Callsign:  license.Call,
+				Callsign:  strings.ToUpper(license.Call),
 				Name:      license.FullName(),
 				Location:  strings.Join([]string{license.City, license.State}, ", "),
 				ErrorType: fmt.Sprintf("%T", logicErr),
@@ -69,7 +69,7 @@ func (n net) Checkin(ctx context.Context, stream string, checkin *models.NetChec
 	return Event.Create(ctx, stream, events.NetCheckinHeard{
 		ID: id.String(),
 
-		Callsign: checkin.Callsign.AsHeard,
+		Callsign: strings.ToUpper(checkin.Callsign.AsHeard),
 		Name:     checkin.Name.AsHeard,
 		Location: checkin.Location.AsHeard,
 		Kind:     checkin.Kind.String(),

--- a/internal/views/layout.templ
+++ b/internal/views/layout.templ
@@ -2,7 +2,7 @@ package views
 
 templ Page() {
 	<!DOCTYPE html>
-	<html>
+	<html lang="en">
 		<head>
 			<title>NetControl</title>
 			<meta charset="utf-8"/>

--- a/internal/views/layout_templ.go
+++ b/internal/views/layout_templ.go
@@ -23,7 +23,7 @@ func Page() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<!doctype html><html><head><title>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<!doctype html><html lang=\"en\"><head><title>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/views/net.templ
+++ b/internal/views/net.templ
@@ -151,7 +151,7 @@ templ (v Net) TrafficTable(streamID string) {
 }
 
 type CheckinFormInput struct {
-	Callsign string `validate:"required"`
+	Callsign string `validate:"required,alphanum"`
 	Name     string
 	Traffic  string `validate:"required"`
 }

--- a/internal/views/net_templ.go
+++ b/internal/views/net_templ.go
@@ -573,7 +573,7 @@ func (v Net) TrafficTable(streamID string) templ.Component {
 }
 
 type CheckinFormInput struct {
-	Callsign string `validate:"required"`
+	Callsign string `validate:"required,alphanum"`
 	Name     string
 	Traffic  string `validate:"required"`
 }


### PR DESCRIPTION
We also now use uppercase callsigns where required and cleanup any leading/trailing spaces.

Close #6